### PR TITLE
feat: 增加lrc歌词核心支持，UI中最小化修改支持上传文件以及计时功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,6 +1048,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/core/beatProvider.ts
+++ b/src/core/beatProvider.ts
@@ -134,6 +134,12 @@ export class BeatProvider {
     return this.audioEl?.duration ?? 0;
   }
 
+  seek(time: number): void {
+    if (!this.audioEl) return;
+    const duration = Number.isFinite(this.audioEl.duration) ? this.audioEl.duration : Infinity;
+    this.audioEl.currentTime = Math.max(0, Math.min(time, duration));
+  }
+
   dispose(): void {
     this.audioEl?.pause();
     this.source?.disconnect();

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -2,7 +2,7 @@
 // Licensed under AGPL-3.0. For commercial use, see COMMERCIAL.md
 
 import * as PIXI from 'pixi.js';
-import type { TemplateConfig, UpdateContext, ColorPalette, LayerType, MotionTargetInfo } from './types';
+import type { TemplateConfig, UpdateContext, ColorPalette, LayerType, MotionTargetInfo, LyricLine } from './types';
 import { createEffect, BaseEffect } from '../effects';
 import { extractDominantColors } from './colorExtractor';
 import { MediaOutlineRenderer } from './mediaOutline';
@@ -26,11 +26,14 @@ export class PVEngine {
   };
   private currentTemplate: TemplateConfig | null = null;
   private userText = '';
-  private startTime = 0;
 
   private _animationSpeed = 2;
   private _motionIntensity = 1;
   private textSegments: string[] = ['春を告げる'];
+  private lyricTimeline: LyricLine[] | null = null;
+  private lyricOffsetSeconds = 0;
+  private lyricCursor = 0;
+  private lastLyricTime = -1;
   private _segmentDuration = 3;
   private _srtTimeline: { startMs: number; endMs: number; text: string }[] | null = null;
   private _effectOpacity = 1;
@@ -67,14 +70,16 @@ export class PVEngine {
   private _loading = false;
   private _bgColorOverride: string | null = null;
   private _tick = 0;
+  private _playbackTime = 0;
+  private _paused = false;
+  private _time = 0;
+  private _lastFrameTime = 0;
 
   constructor() {
     this.app = new PIXI.Application();
     this.hueFilter = new PIXI.ColorMatrixFilter();
     this.glitchFilter = new GlitchFilter();
   }
-
-  private static readonly _solaris = [115,111,108,97,114,105,115];
 
   async init(parent: HTMLElement) {
     this._nativeDPR = Math.min(window.devicePixelRatio || 1, 3);
@@ -111,14 +116,45 @@ export class PVEngine {
       this.effectsRoot.addChild(container);
     }
 
-    this.startTime = performance.now();
+    this._lastFrameTime = performance.now();
 
     this.app.stage.filters = [this.hueFilter, this.glitchFilter];
 
     this.app.ticker.add((ticker) => {
-      const time = (performance.now() - this.startTime) / 1000;
-      this.update(time, ticker.deltaTime / 60);
+      const now = performance.now();
+      const dt = (now - this._lastFrameTime) / 1000;
+      this._lastFrameTime = now;
+
+      if (!this._paused) {
+        if (this.beat.isAudioMode) {
+          this._time = this.beat.currentTime;
+        } else {
+          this._time += dt;
+        }
+      }
+
+      this.update(this._time, ticker.deltaTime / 60);
     });
+  }
+
+  get paused() { return this._paused; }
+
+  pause() {
+    this._paused = true;
+    this.beat.pause();
+  }
+
+  resume() {
+    this._paused = false;
+    this._lastFrameTime = performance.now();
+    this.beat.resume();
+  }
+
+  seek(time: number) {
+    this._time = Math.max(0, time);
+    if (this.beat.isAudioMode) {
+      this.beat.seek(this._time);
+    }
   }
 
   loadTemplate(template: TemplateConfig) {
@@ -180,6 +216,7 @@ export class PVEngine {
   }
 
   setText(text: string) {
+    this.clearLyricTimeline();
     this.userText = text;
     this.textSegments = text
       .split('/')
@@ -204,6 +241,89 @@ export class PVEngine {
 
   setSrtTimeline(entries: { startMs: number; endMs: number; text: string }[] | null) {
     this._srtTimeline = entries;
+    if (entries && entries.length > 0) {
+      this.clearLyricTimeline();
+    }
+  }
+
+  setLyricTimeline(lines: LyricLine[]): void {
+    if (lines.length === 0) {
+      this.clearLyricTimeline();
+      return;
+    }
+
+    this._srtTimeline = null;
+    this.lyricTimeline = [...lines].sort((a, b) => a.time - b.time);
+    this.lyricCursor = 0;
+    this.lastLyricTime = -1;
+
+    this.userText = this.lyricTimeline[0].text;
+    this.textSegments = [this.userText];
+
+    if (this.currentTemplate) {
+      this.loadTemplate(this.currentTemplate);
+    }
+  }
+
+  clearLyricTimeline(): void {
+    this.lyricTimeline = null;
+    this.lyricCursor = 0;
+    this.lastLyricTime = -1;
+    this.lyricOffsetSeconds = 0;
+  }
+
+  get hasLyricTimeline(): boolean {
+    return !!this.lyricTimeline && this.lyricTimeline.length > 0;
+  }
+
+  get lyricLineCount(): number {
+    return this.lyricTimeline?.length ?? 0;
+  }
+
+  set lyricOffset(val: number) {
+    this.lyricOffsetSeconds = val;
+  }
+
+  get lyricOffset(): number {
+    return this.lyricOffsetSeconds;
+  }
+
+  private getDisplayText(time: number): string {
+    if (this._srtTimeline) {
+      const ms = time * 1000;
+      const entry = this._srtTimeline.find(e => ms >= e.startMs && ms < e.endMs);
+      return entry?.text ?? '';
+    }
+
+    if (!this.lyricTimeline || this.lyricTimeline.length === 0) {
+      const segIdx = this.textSegments.length > 1
+        ? Math.floor(time / this._segmentDuration) % this.textSegments.length
+        : 0;
+      return this.textSegments[segIdx] || '';
+    }
+
+    const t = Math.max(0, time + this.lyricOffsetSeconds);
+    if (t < this.lastLyricTime) {
+      this.lyricCursor = 0;
+    }
+    this.lastLyricTime = t;
+
+    while (
+      this.lyricCursor + 1 < this.lyricTimeline.length
+      && this.lyricTimeline[this.lyricCursor + 1].time <= t
+    ) {
+      this.lyricCursor++;
+    }
+
+    while (
+      this.lyricCursor > 0
+      && this.lyricTimeline[this.lyricCursor].time > t
+    ) {
+      this.lyricCursor--;
+    }
+
+    if (t < this.lyricTimeline[0].time) return '';
+    return this.lyricTimeline[this.lyricCursor].text;
   }
 
   set effectOpacity(val: number) {
@@ -577,17 +697,8 @@ export class PVEngine {
   }
 
   private update(time: number, deltaTime: number) {
-    let currentText: string;
-    if (this._srtTimeline) {
-      const ms = time * 1000;
-      const entry = this._srtTimeline.find(e => ms >= e.startMs && ms < e.endMs);
-      currentText = entry?.text ?? '';
-    } else {
-      const segIdx = this.textSegments.length > 1
-        ? Math.floor(time / this._segmentDuration) % this.textSegments.length
-        : 0;
-      currentText = this.textSegments[segIdx] || '';
-    }
+    const lyricClock = this.beat.isAudioMode ? this.beat.currentTime : time;
+    this._playbackTime = lyricClock;
 
     if (this.motionDetector && this.mediaElement instanceof HTMLVideoElement) {
       this.motionDetector.detect(this.mediaElement);
@@ -606,7 +717,7 @@ export class PVEngine {
       palette: this.palette,
       animationSpeed: this._animationSpeed,
       motionIntensity: this._motionIntensity,
-      currentText,
+      currentText: this.getDisplayText(lyricClock),
       beatIntensity: this.beat.getIntensity(time) * this._beatReactivity,
       motionTargets: this.motionTargets,
     };
@@ -663,6 +774,23 @@ export class PVEngine {
 
   get canvas(): HTMLCanvasElement {
     return this.app.canvas as HTMLCanvasElement;
+  }
+
+  get playbackTime(): number {
+    return this._playbackTime;
+  }
+
+  get timelineDuration(): number {
+    const audioDuration = this.beat.duration;
+    if (Number.isFinite(audioDuration) && audioDuration > 0) {
+      return audioDuration;
+    }
+
+    if (this.lyricTimeline && this.lyricTimeline.length > 0) {
+      return Math.max(this.lyricTimeline[this.lyricTimeline.length - 1].time + 2, 1);
+    }
+
+    return Math.max(this.textSegments.length * this._segmentDuration, this._segmentDuration);
   }
 
   destroy() {

--- a/src/core/lrc.ts
+++ b/src/core/lrc.ts
@@ -1,0 +1,60 @@
+// PV Tool — Copyright (c) 2026 DanteAlighieri13210914
+// Licensed under AGPL-3.0. For commercial use, see COMMERCIAL.md
+
+import type { LyricLine } from './types';
+
+const TIME_TAG_RE = /\[(\d{1,2}):(\d{2})(?:[.:](\d{1,3}))?\]/g;
+const META_TAG_RE = /^\s*\[[a-zA-Z]+:.*\]\s*$/;
+
+function parseTimeToSeconds(minStr: string, secStr: string, fracStr?: string): number {
+  const min = Number.parseInt(minStr, 10);
+  const sec = Number.parseInt(secStr, 10);
+  let frac = 0;
+
+  if (fracStr) {
+    if (fracStr.length === 1) frac = Number.parseInt(fracStr, 10) / 10;
+    else if (fracStr.length === 2) frac = Number.parseInt(fracStr, 10) / 100;
+    else frac = Number.parseInt(fracStr.slice(0, 3), 10) / 1000;
+  }
+
+  return min * 60 + sec + frac;
+}
+
+export function parseLrc(content: string): LyricLine[] {
+  const lines = content.replace(/^\uFEFF/, '').split(/\r?\n/);
+  const result: LyricLine[] = [];
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || META_TAG_RE.test(line)) continue;
+
+    TIME_TAG_RE.lastIndex = 0;
+    const times: number[] = [];
+
+    let match: RegExpExecArray | null;
+    while ((match = TIME_TAG_RE.exec(line)) !== null) {
+      times.push(parseTimeToSeconds(match[1], match[2], match[3]));
+    }
+
+    if (times.length === 0) continue;
+
+    const text = line.replace(TIME_TAG_RE, '').trim();
+    for (const time of times) {
+      result.push({ time, text });
+    }
+  }
+
+  result.sort((a, b) => a.time - b.time);
+  return result;
+}
+
+export function formatTime(time: number): string {
+  const min = Math.floor(time / 60);
+  const sec = Math.floor(time % 60);
+  const ms = Math.floor((time % 1) * 100);
+  return `[${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}.${ms.toString().padStart(2, '0')}]`;
+}
+
+export function formatLrc(lines: LyricLine[]): string {
+  return lines.map((line) => `${formatTime(line.time)} ${line.text}`).join('\n');
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,6 +73,11 @@ export interface LyricPhrase {
   endTime: number;
 }
 
+export interface LyricLine {
+  time: number;
+  text: string;
+}
+
 export interface Segment {
   type: 'verse' | 'chorus' | 'bridge';
   startTime: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -361,7 +361,7 @@ function applyTextInput(rawText: string): void {
   }
 
   engine.clearLyricTimeline();
-  engine.setText(rawText.replace(/\n/g, '/'));
+  engine.setText(rawText.replace(/\r?\n/g, '/'));
 }
 
 textInput.addEventListener('input', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -360,7 +360,6 @@ function applyTextInput(rawText: string): void {
     }
   }
 
-  engine.clearLyricTimeline();
   engine.setText(rawText.replace(/\r?\n/g, '/'));
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 
 import './style.css';
 import { PVEngine } from './core/engine';
+import { parseLrc } from './core/lrc';
 import { templates } from './templates';
 import { effectCatalog } from './core/effectCatalog';
 import type { TemplateConfig } from './core/types';
@@ -50,6 +51,20 @@ app.innerHTML = `
       <div class="control-group">
         <label>${t('text_label')}</label>
         <textarea id="text-input" rows="1" placeholder="深夜東京/の6畳半夢">深夜東京/の6畳半夢/を見てた/灯りの灯らない蛍光灯/明日には消えてる電脳城/に/開幕戦/打ち上げて/いなくなんないよね/ここには誰もいない/ここには誰もいないから</textarea>
+      </div>
+
+      <div class="control-group">
+        <label>LRC</label>
+        <div class="file-pick">
+          <button class="btn btn-sm" id="lrc-pick-btn">导入 LRC</button>
+          <span class="file-pick-name" id="lrc-pick-name">未选择文件</span>
+          <input type="file" id="lrc-input" accept=".lrc,text/plain" hidden>
+        </div>
+      </div>
+
+      <div class="control-group">
+        <label>计时 Time</label>
+        <div id="playback-time">00:00 / 00:00</div>
       </div>
 
       <div class="control-group">
@@ -334,12 +349,62 @@ textInput.addEventListener('blur', () => {
 });
 
 let textTimer: ReturnType<typeof setTimeout>;
+
+function applyTextInput(rawText: string): void {
+  const hasTimestamps = /\[\d{1,2}:\d{2}/.test(rawText);
+  if (hasTimestamps) {
+    const parsed = parseLrc(rawText);
+    if (parsed.length > 0) {
+      engine.setLyricTimeline(parsed);
+      return;
+    }
+  }
+
+  engine.clearLyricTimeline();
+  engine.setText(rawText.replace(/\n/g, '/'));
+}
+
 textInput.addEventListener('input', () => {
   clearTimeout(textTimer);
   textTimer = setTimeout(() => {
-    engine.setText(textInput.value);
+    applyTextInput(textInput.value);
   }, 400);
 });
+
+const lrcInput = document.getElementById('lrc-input') as HTMLInputElement;
+const lrcPickBtn = document.getElementById('lrc-pick-btn') as HTMLButtonElement;
+const lrcPickName = document.getElementById('lrc-pick-name')!;
+
+lrcPickBtn.addEventListener('click', () => lrcInput.click());
+
+lrcInput.addEventListener('change', async () => {
+  const file = lrcInput.files?.[0];
+  if (!file) return;
+
+  lrcPickName.textContent = file.name;
+  const content = await file.text();
+  textInput.value = content;
+  applyTextInput(content);
+  lrcInput.value = '';
+});
+
+const playbackTimeEl = document.getElementById('playback-time')!;
+
+function formatClock(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+function updatePlaybackTimer(): void {
+  const current = engine.playbackTime;
+  const total = engine.timelineDuration;
+  playbackTimeEl.textContent = `${formatClock(current)} / ${formatClock(total)}`;
+  requestAnimationFrame(updatePlaybackTimer);
+}
+
+requestAnimationFrame(updatePlaybackTimer);
 
 // Segment duration
 const segSlider = document.getElementById('seg-slider') as HTMLInputElement;


### PR DESCRIPTION
- 添加LRC格式解析器 (src/core/lrc.ts)
- 扩展引擎支持LRC时间轴模式，支持歌词偏移调整(UI未实现)
- 添加播放控制：pause()、resume()、seek() 方法 （UI未实现）
- 新增UI：LRC文件导入按钮和实时播放计时显示
- 自动检测粘贴文本中的LRC格式并切换模式