### PR TITLE
feat: 自定义模板管理与分享码导入导出

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,6 +1048,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/core/templateStore.ts
+++ b/src/core/templateStore.ts
@@ -1,0 +1,129 @@
+// PV Tool — Copyright (c) 2026 DanteAlighieri13210914
+// Licensed under AGPL-3.0. For commercial use, see COMMERCIAL.md
+
+import type { TemplateConfig } from './types';
+
+const STORAGE_KEY = 'pv-tool-custom-templates';
+const SHARE_KEY = 'PV2026';
+
+// ── LocalStorage persistence ──
+
+export function loadCustomTemplates(): TemplateConfig[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as TemplateConfig[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomTemplates(templates: TemplateConfig[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+}
+
+export function addCustomTemplate(template: TemplateConfig): TemplateConfig[] {
+  const list = loadCustomTemplates();
+  list.push(template);
+  saveCustomTemplates(list);
+  return list;
+}
+
+export function removeCustomTemplate(index: number): TemplateConfig[] {
+  const list = loadCustomTemplates();
+  list.splice(index, 1);
+  saveCustomTemplates(list);
+  return list;
+}
+
+// ── Share code: serialize → compress → XOR encrypt → base64 ──
+
+function xorCipher(data: Uint8Array, key: string): Uint8Array {
+  const result = new Uint8Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    result[i] = data[i] ^ key.charCodeAt(i % key.length);
+  }
+  return result;
+}
+
+async function compressBytes(data: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream('deflate');
+  const writer = cs.writable.getWriter();
+  writer.write(data as unknown as BufferSource);
+  writer.close();
+  const reader = cs.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((s, c) => s + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return result;
+}
+
+async function decompressBytes(data: Uint8Array): Promise<Uint8Array> {
+  const ds = new DecompressionStream('deflate');
+  const writer = ds.writable.getWriter();
+  writer.write(data as unknown as BufferSource);
+  writer.close();
+  const reader = ds.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((s, c) => s + c.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    result.set(c, offset);
+    offset += c.length;
+  }
+  return result;
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function encodeShareCode(template: TemplateConfig): Promise<string> {
+  const json = JSON.stringify(template);
+  const raw = new TextEncoder().encode(json);
+  const compressed = await compressBytes(raw);
+  const encrypted = xorCipher(compressed, SHARE_KEY);
+  return uint8ToBase64(encrypted);
+}
+
+export async function decodeShareCode(code: string): Promise<TemplateConfig> {
+  const cleaned = code.trim().replace(/\s+/g, '');
+  const encrypted = base64ToUint8(cleaned);
+  const compressed = xorCipher(encrypted, SHARE_KEY);
+  const raw = await decompressBytes(compressed);
+  const json = new TextDecoder().decode(raw);
+  const template = JSON.parse(json) as TemplateConfig;
+  if (!template.name || !template.palette || !Array.isArray(template.effects)) {
+    throw new Error('Invalid template data');
+  }
+  return template;
+}

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -87,8 +87,8 @@ export const ja: Record<LocaleKey, string> = {
   'no_file': '未選択',
 
   // Sharecode & template management
-  'export_code': '設定コード出力',
-  'import_code': '設定コード入力',
+  'export_code': 'シェアコード出力',
+  'import_code': 'シェアコード入力',
   'import_btn': '読込',
   'code_copied': 'コピー済',
   'code_invalid': 'コード無効',
@@ -101,7 +101,7 @@ export const ja: Record<LocaleKey, string> = {
   'share_code': 'シェアコード Share Code',
   'copy': 'コピー',
   'paste_code': 'シェアコードを貼り付け...',
-  'import_share': 'シェアコード読込',
+
 
   // Effect categories
   'ecat_背景': '背景',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -80,17 +80,28 @@ export const ja: Record<LocaleKey, string> = {
   'tpl_spiderWeb': 'スパイダーウェブ',
   'tpl_staggeredText': 'スタッガードテキスト',
   'tpl_calmVillain': 'クールヴィラン',
+  'tpl_girlyClouds': 'ガーリークラウド',
 
   // File picker
   'choose_file': 'ファイル選択',
   'no_file': '未選択',
 
-  // Sharecode
+  // Sharecode & template management
   'export_code': '設定コード出力',
   'import_code': '設定コード入力',
   'import_btn': '読込',
   'code_copied': 'コピー済',
   'code_invalid': 'コード無効',
+  'save_tpl': '保存',
+  'delete_tpl': '削除',
+  'confirm': '確認',
+  'cancel': 'キャンセル',
+  'tpl_name_placeholder': 'テンプレート名を入力...',
+  'confirm_delete': '削除確認',
+  'share_code': 'シェアコード Share Code',
+  'copy': 'コピー',
+  'paste_code': 'シェアコードを貼り付け...',
+  'import_share': 'シェアコード読込',
 
   // Effect categories
   'ecat_背景': '背景',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -85,11 +85,11 @@ export const zh = {
   'no_file': '未选择文件',
 
   // Sharecode & template management
-  'export_code': '导出配置码',
-  'import_code': '导入配置码',
+  'export_code': '导出分享码',
+  'import_code': '导入分享码',
   'import_btn': '导入',
   'code_copied': '已复制',
-  'code_invalid': '配置码无效',
+  'code_invalid': '分享码无效',
   'save_tpl': '保存',
   'delete_tpl': '删除',
   'confirm': '确认',
@@ -99,7 +99,7 @@ export const zh = {
   'share_code': '分享码 Share Code',
   'copy': '复制',
   'paste_code': '粘贴分享码...',
-  'import_share': '导入分享码',
+
 
   // Effect categories (used in custom panel)
   'ecat_背景': '背景',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -78,17 +78,28 @@ export const zh = {
   'tpl_spiderWeb': '蛛网',
   'tpl_staggeredText': '错落文字',
   'tpl_calmVillain': '冷静的反派',
+  'tpl_girlyClouds': '少女云朵',
 
   // File picker
   'choose_file': '选择文件',
   'no_file': '未选择文件',
 
-  // Sharecode
+  // Sharecode & template management
   'export_code': '导出配置码',
   'import_code': '导入配置码',
   'import_btn': '导入',
   'code_copied': '已复制',
   'code_invalid': '配置码无效',
+  'save_tpl': '保存',
+  'delete_tpl': '删除',
+  'confirm': '确认',
+  'cancel': '取消',
+  'tpl_name_placeholder': '输入模板名称...',
+  'confirm_delete': '确认删除',
+  'share_code': '分享码 Share Code',
+  'copy': '复制',
+  'paste_code': '粘贴分享码...',
+  'import_share': '导入分享码',
 
   // Effect categories (used in custom panel)
   'ecat_背景': '背景',

--- a/src/main.ts
+++ b/src/main.ts
@@ -462,7 +462,7 @@ tplExportBtn.addEventListener('click', async () => {
 tplImportBtn.addEventListener('click', () => {
   shareCodeMode = 'import';
   shareCodeLabel.classList.remove('label-error');
-  shareCodeLabel.textContent = t('import_share');
+  shareCodeLabel.textContent = t('import_code');
   shareCodeText.value = '';
   shareCodeText.readOnly = false;
   shareCodeOk.textContent = t('import_btn');

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,12 @@ import { templates } from './templates';
 import { effectCatalog } from './core/effectCatalog';
 import type { TemplateConfig } from './core/types';
 import { t } from './i18n';
-
+import {
+  loadCustomTemplates,
+  saveCustomTemplates,
+  encodeShareCode,
+  decodeShareCode,
+} from './core/templateStore';
 
 console.log('%cPV Tool%c solaris:0914', 'color:#6688cc;font-weight:bold', 'color:#888');
 
@@ -24,11 +29,34 @@ app.innerHTML = `
   <div class="panels-wrapper" id="panels-wrapper">
     <div class="controls">
       <div class="control-group">
-        <label>${t('template')}</label>
+        <label class="label-with-action">${t('template')} <button class="btn btn-sm btn-label" id="tpl-import" title="${t('import_code')}">${t('import_code')}</button></label>
         <select id="template-select">
           ${templates.map((tp, i) => `<option value="${i}">${tplName(tp)}</option>`).join('')}
           <option value="custom">${t('custom')}</option>
         </select>
+        <div class="template-actions">
+          <button class="btn btn-sm" id="tpl-save" title="${t('save_tpl')}" style="display:none">${t('save_tpl')}</button>
+          <button class="btn btn-sm" id="tpl-delete" title="${t('delete_tpl')}" style="display:none">${t('delete_tpl')}</button>
+          <button class="btn btn-sm" id="tpl-export" title="${t('export_code')}" style="display:none">${t('export_code')}</button>
+        </div>
+        <div id="tpl-save-input" class="tpl-inline-input" style="display:none">
+          <input type="text" id="tpl-name-input" placeholder="${t('tpl_name_placeholder')}">
+          <button class="btn btn-sm" id="tpl-save-ok">${t('confirm')}</button>
+          <button class="btn btn-sm" id="tpl-save-cancel">${t('cancel')}</button>
+        </div>
+        <div id="tpl-delete-confirm" class="tpl-inline-input" style="display:none">
+          <span class="tpl-confirm-text" id="tpl-delete-text"></span>
+          <button class="btn btn-sm btn-danger" id="tpl-delete-ok">${t('delete_tpl')}</button>
+          <button class="btn btn-sm" id="tpl-delete-cancel">${t('cancel')}</button>
+        </div>
+      </div>
+      <div class="control-group" id="share-code-group" style="display:none">
+        <label id="share-code-label">${t('share_code')}</label>
+        <textarea id="share-code-text" rows="3" placeholder="${t('paste_code')}"></textarea>
+        <div class="template-actions">
+          <button class="btn btn-sm" id="share-code-ok">${t('confirm')}</button>
+          <button class="btn btn-sm" id="share-code-cancel">${t('cancel')}</button>
+        </div>
       </div>
 
       <div class="control-group">
@@ -297,6 +325,12 @@ templateSelect.addEventListener('change', () => {
     isCustomMode = true;
     customPanel.style.display = '';
     engine.loadTemplate(buildCustomTemplate());
+  } else if (val.startsWith('user-')) {
+    isCustomMode = false;
+    customPanel.style.display = 'none';
+    const idx = parseInt(val.split('-')[1]);
+    engine.loadTemplate(customTemplates[idx]);
+    syncSpeedSlider();
   } else {
     isCustomMode = false;
     customPanel.style.display = 'none';
@@ -304,7 +338,173 @@ templateSelect.addEventListener('change', () => {
     syncSpeedSlider();
     syncOpacitySlider();
   }
+  updateTemplateButtons();
 });
+
+// ── Custom template management ──
+let customTemplates = loadCustomTemplates();
+
+function rebuildTemplateSelect() {
+  const builtInHtml = templates.map((tp, i) => `<option value="${i}">${tplName(tp)}</option>`).join('');
+  const customHtml = customTemplates.map((tp, i) =>
+    `<option value="user-${i}">⭐ ${tp.name}</option>`
+  ).join('');
+  templateSelect.innerHTML = builtInHtml + customHtml + `<option value="custom">${t('custom')}</option>`;
+}
+
+function updateTemplateButtons() {
+  const val = templateSelect.value;
+  const isUser = val.startsWith('user-');
+  const isCustom = val === 'custom';
+  tplSaveBtn.style.display = isCustom ? '' : 'none';
+  tplDeleteBtn.style.display = isUser ? '' : 'none';
+  tplExportBtn.style.display = isUser ? '' : 'none';
+  // Hide inline inputs when switching
+  tplSaveInput.style.display = 'none';
+  tplDeleteConfirm.style.display = 'none';
+}
+
+const tplSaveBtn = document.getElementById('tpl-save')!;
+const tplDeleteBtn = document.getElementById('tpl-delete')!;
+const tplExportBtn = document.getElementById('tpl-export')!;
+const tplImportBtn = document.getElementById('tpl-import')!;
+const tplSaveInput = document.getElementById('tpl-save-input')!;
+const tplNameInput = document.getElementById('tpl-name-input') as HTMLInputElement;
+const tplSaveOk = document.getElementById('tpl-save-ok')!;
+const tplSaveCancel = document.getElementById('tpl-save-cancel')!;
+const tplDeleteConfirm = document.getElementById('tpl-delete-confirm')!;
+const tplDeleteText = document.getElementById('tpl-delete-text')!;
+const tplDeleteOk = document.getElementById('tpl-delete-ok')!;
+const tplDeleteCancel = document.getElementById('tpl-delete-cancel')!;
+const shareCodeGroup = document.getElementById('share-code-group')!;
+const shareCodeLabel = document.getElementById('share-code-label')!;
+const shareCodeText = document.getElementById('share-code-text') as HTMLTextAreaElement;
+const shareCodeOk = document.getElementById('share-code-ok')!;
+const shareCodeCancel = document.getElementById('share-code-cancel')!;
+
+let shareCodeMode: 'import' | 'export' = 'import';
+
+// Save: show inline name input
+tplSaveBtn.addEventListener('click', () => {
+  tplSaveInput.style.display = '';
+  tplNameInput.value = '';
+  tplNameInput.focus();
+});
+
+tplSaveCancel.addEventListener('click', () => {
+  tplSaveInput.style.display = 'none';
+});
+
+function doSave() {
+  const name = tplNameInput.value.trim();
+  if (!name) return;
+  const tpl = { ...buildCustomTemplate(), name };
+  customTemplates.push(tpl);
+  saveCustomTemplates(customTemplates);
+  rebuildTemplateSelect();
+  templateSelect.value = `user-${customTemplates.length - 1}`;
+  isCustomMode = false;
+  customPanel.style.display = 'none';
+  engine.loadTemplate(tpl);
+  updateTemplateButtons();
+  syncSpeedSlider();
+}
+
+tplSaveOk.addEventListener('click', doSave);
+tplNameInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') doSave();
+  if (e.key === 'Escape') tplSaveInput.style.display = 'none';
+});
+
+// Delete: show inline confirmation
+tplDeleteBtn.addEventListener('click', () => {
+  const val = templateSelect.value;
+  if (!val.startsWith('user-')) return;
+  const idx = parseInt(val.split('-')[1]);
+  tplDeleteText.textContent = `${t('confirm_delete')} "${customTemplates[idx].name}"？`;
+  tplDeleteConfirm.style.display = '';
+});
+
+tplDeleteCancel.addEventListener('click', () => {
+  tplDeleteConfirm.style.display = 'none';
+});
+
+tplDeleteOk.addEventListener('click', () => {
+  const val = templateSelect.value;
+  if (!val.startsWith('user-')) return;
+  const idx = parseInt(val.split('-')[1]);
+  customTemplates.splice(idx, 1);
+  saveCustomTemplates(customTemplates);
+  rebuildTemplateSelect();
+  templateSelect.value = '0';
+  engine.loadTemplate(templates[0]);
+  updateTemplateButtons();
+  syncSpeedSlider();
+  tplDeleteConfirm.style.display = 'none';
+});
+
+// Export share code
+tplExportBtn.addEventListener('click', async () => {
+  const val = templateSelect.value;
+  if (!val.startsWith('user-')) return;
+  const idx = parseInt(val.split('-')[1]);
+  shareCodeMode = 'export';
+  shareCodeLabel.textContent = `${t('share_code')} (${t('code_copied')})`;
+  const code = await encodeShareCode(customTemplates[idx]);
+  shareCodeText.value = code;
+  shareCodeGroup.style.display = '';
+  shareCodeText.readOnly = true;
+  shareCodeOk.textContent = t('copy');
+  try { await navigator.clipboard.writeText(code); } catch { /* fallback: user copies manually */ }
+});
+
+// Import share code
+tplImportBtn.addEventListener('click', () => {
+  shareCodeMode = 'import';
+  shareCodeLabel.classList.remove('label-error');
+  shareCodeLabel.textContent = t('import_share');
+  shareCodeText.value = '';
+  shareCodeText.readOnly = false;
+  shareCodeOk.textContent = t('import_btn');
+  shareCodeGroup.style.display = '';
+});
+
+shareCodeOk.addEventListener('click', async () => {
+  if (shareCodeMode === 'export') {
+    try { await navigator.clipboard.writeText(shareCodeText.value); } catch { /* noop */ }
+    shareCodeGroup.style.display = 'none';
+    return;
+  }
+  // Import
+  const code = shareCodeText.value.trim();
+  if (!code) return;
+  try {
+    const tpl = await decodeShareCode(code);
+    customTemplates.push(tpl);
+    saveCustomTemplates(customTemplates);
+    rebuildTemplateSelect();
+    const newIdx = customTemplates.length - 1;
+    templateSelect.value = `user-${newIdx}`;
+    isCustomMode = false;
+    customPanel.style.display = 'none';
+    engine.loadTemplate(tpl);
+    updateTemplateButtons();
+    syncSpeedSlider();
+    shareCodeGroup.style.display = 'none';
+  } catch (err) {
+    shareCodeLabel.textContent = t('code_invalid');
+    shareCodeLabel.classList.add('label-error');
+    console.warn('[PV] Share code decode failed:', err);
+    return;
+  }
+});
+
+shareCodeCancel.addEventListener('click', () => {
+  shareCodeGroup.style.display = 'none';
+});
+
+// Rebuild select to include saved custom templates
+rebuildTemplateSelect();
 
 let customRebuildTimer: ReturnType<typeof setTimeout>;
 effectGrid.addEventListener('change', () => {

--- a/src/style.css
+++ b/src/style.css
@@ -322,6 +322,84 @@ input[type='range'] {
   min-width: 40px;
 }
 
+/* Template actions */
+.template-actions {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.btn-sm {
+  margin-top: 0;
+  padding: 3px 8px;
+  font-size: 0.7rem;
+}
+
+.btn-danger {
+  border-color: rgba(255, 80, 80, 0.5);
+  background: rgba(255, 50, 50, 0.25);
+}
+
+.btn-danger:hover {
+  background: rgba(255, 50, 50, 0.4);
+}
+
+.label-with-action {
+  display: flex !important;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+
+.btn-label {
+  padding: 2px 8px;
+  font-size: 0.65rem;
+  font-weight: normal;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.tpl-inline-input {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.tpl-inline-input input[type="text"] {
+  flex: 1;
+  padding: 4px 8px;
+  font-size: 0.8rem;
+}
+
+.label-error {
+  color: rgba(255, 120, 120, 0.9) !important;
+}
+
+.tpl-confirm-text {
+  font-size: 0.72rem;
+  color: rgba(255, 180, 180, 0.9);
+  flex: 1;
+}
+
+#share-code-text {
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-size: 0.75rem;
+  font-family: 'Courier New', monospace;
+  resize: vertical;
+  outline: none;
+}
+
+#share-code-text:focus {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
 /* Canvas color swatches */
 .color-swatches {
   display: flex;


### PR DESCRIPTION
- 支持将自定义效果组合保存为命名模板，持久化到 localStorage
- 自定义模板在下拉菜单中以 ⭐ 前缀显示，支持删除
- 导出分享码：JSON 序列化 → Deflate 压缩 → XOR 加密 → Base64
- 导入分享码：粘贴即可还原模板，自动保存到本地
- 所有交互使用内联 UI，无弹窗