### PR TITLE
feat: 添加限制预览帧率的功能

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -77,6 +77,10 @@ export class PVEngine {
   private _paused = false;
   private _time = 0;
   private _lastFrameTime = 0;
+  private _previewFps = 0;
+  private _fpsFrameCount = 0;
+  private _fpsLastTime = 0;
+  onFpsUpdate: ((fps: number) => void) | null = null;
 
   // Now Playing state
   private npProvider: NowPlayingProvider | null = null;
@@ -149,6 +153,14 @@ export class PVEngine {
         } else {
           this._time += dt;
         }
+      }
+
+      this._fpsFrameCount++;
+      if (now - this._fpsLastTime >= 1000) {
+        const fps = Math.round(this._fpsFrameCount * 1000 / (now - this._fpsLastTime));
+        if (this.onFpsUpdate) this.onFpsUpdate(fps);
+        this._fpsFrameCount = 0;
+        this._fpsLastTime = now;
       }
 
       this.update(this._time, ticker.deltaTime / 60);
@@ -544,6 +556,12 @@ export class PVEngine {
 
   set beatReactivity(val: number) { this._beatReactivity = val; }
   get beatReactivity() { return this._beatReactivity; }
+
+  setPreviewFps(fps: number) {
+    this._previewFps = fps;
+    this.app.ticker.maxFPS = fps > 0 ? fps : 0;
+  }
+  getPreviewFps() { return this._previewFps; }
 
   set canvasColor(color: string | null) {
     this._bgColorOverride = color;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -32,6 +32,8 @@ export const en: Record<LocaleKey, string> = {
   'paused': '⏹ Paused',
   'bpm': 'BPM',
   'beat_react': 'Beat React',
+  'preview_fps': 'Limit Preview FPS',
+  'fps_unlimited': 'Unlimited',
 
   // Right panel — Post FX
   'shake': 'Shake',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -32,6 +32,8 @@ export const ja: Record<LocaleKey, string> = {
   'paused': '⏹ 停止中',
   'bpm': 'BPM',
   'beat_react': 'ビート反応 Beat React',
+  'preview_fps': 'プレビューFPS制限',
+  'fps_unlimited': '無制限',
 
   // Right panel — Post FX
   'shake': 'シェイク Shake',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -30,6 +30,8 @@ export const zh = {
   'paused': '⏹ Paused',
   'bpm': 'BPM',
   'beat_react': '节拍反应 Beat React',
+  'preview_fps': '限制预览帧率',
+  'fps_unlimited': '无限制 Unlimited',
 
   // Right panel — Post FX
   'shake': '抖动 Shake',

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,23 @@ app.innerHTML = `
         <label>${t('beat_react')} <span id="beat-val">0.5</span></label>
         <input type="range" id="beat-slider" min="0" max="1" step="0.05" value="0.5">
       </div>
+
+      <div class="control-group">
+        <label>${t('preview_fps')} <span id="fps-actual"></span></label>
+        <select id="fps-select">
+          <option value="0">${t('fps_unlimited')}</option>
+          <option value="24">24 fps</option>
+          <option value="25">25 fps</option>
+          <option value="30">30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="75">75 fps</option>
+          <option value="120">120 fps</option>
+          <option value="144">144 fps</option>
+          <option value="165">165 fps</option>
+          <option value="240">240 fps</option>
+        </select>
+      </div>
       </details>
 
       <div class="hide-hint" id="hide-hint">${t('hint_press')} <kbd>H</kbd> ${t('hint_hide_panels')}</div>
@@ -877,6 +894,15 @@ beatSlider.addEventListener('input', () => {
   engine.beatReactivity = v;
   beatVal.textContent = v.toFixed(2);
 });
+
+const fpsSelect = document.getElementById('fps-select') as HTMLSelectElement;
+const fpsActualEl = document.getElementById('fps-actual')!;
+fpsSelect.addEventListener('change', () => {
+  engine.setPreviewFps(parseInt(fpsSelect.value));
+});
+engine.onFpsUpdate = (fps: number) => {
+  fpsActualEl.textContent = `(${fps} fps)`;
+};
 
 // Media upload
 const mediaInput = document.getElementById('media-input') as HTMLInputElement;


### PR DESCRIPTION
**在持续实时预览的场景下，通过限制FPS来节能减排。**

实测效果如下：

未限制FPS，集显直接跑满

<img width="1760" height="548" alt="image" src="https://github.com/user-attachments/assets/3d1e0fc3-3b3d-489f-9bcc-914968ff4498" />

限制FPS，显著降低开销
<img width="1759" height="398" alt="image" src="https://github.com/user-attachments/assets/576f3d28-9bcf-42b5-94af-ecc19abcf780" />

