### PR TITLE
feat: 添加自定义字体选择功能，支持加载本地字体并更新效果；修复部分效果不适配自定义字体的问题；增加了适用于Vibe Coding的Copilot提示文件

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# PV Tool AI 编程指南
+
+## 项目架构与理念
+- **领域：** 一个基于 **PixiJS 8** 构建的、用于音乐视频 (PV) 的浏览器端动态排版和视觉效果引擎。
+- **技术栈：** 原生 TypeScript + Vite + PixiJS + GSAP。**没有使用 UI 框架** (React/Vue)；UI 是通过 `src/main.ts` 中的 DOM 操作渲染的。
+- **核心引擎：** `src/core/engine.ts` 是中央协调器。它管理 PixiJS Application、图层堆叠 (`background`, `decoration`, `media`, `text`, `overlay`)、音频同步 (`beatProvider`)，并触发运行循环。
+
+## 关键开发者工作流
+- **启动开发服务器：** 运行 `npm run dev` 
+- **生产构建：** 运行 `npm run build`
+
+## 项目特定的编码约定
+
+### 1. 创建新效果 (`src/effects/`)
+- 在 `src/effects/` 中创建一个新文件，并继承 `BaseEffect` (来自 `src/effects/base.ts`)。
+- **必须实现：** 实现 `abstract readonly name: string`，`protected setup()`，以及 `update(ctx: UpdateContext)`。
+- **性能：** 如果该效果会创建繁重的形状或需要密集的计算，请在类内部设置 `readonly heavy: boolean = true;`，以便引擎可以在低端设备上对其进行节流。
+- **添加元素：** 始终在 `setup()` 中将 PixiJS 显示对象（Graphics、Text、Sprites）添加到 `this.container`。
+- **注册：** 为了不让新效果不可用，请在 `src/effects/index.ts` 中导出它，并在 `src/core/effectCatalog.ts` 中注册它。
+
+### 2. 创建新模板 (`src/templates/`)
+- 模板通过组合多个效果来定义视觉主题。
+- 创建一个符合 `TemplateConfig` 接口（定义在 `src/core/types.ts` 中）的新模板配置。
+- 包含 `palette`，`effects` 数组（具有 `type`、`layer` 和 `config`），以及可选的 `postfx` 或 features。
+- 导出并将新模板追加到 `src/templates/index.ts` 内部的列表中。
+
+### 3. 数据流与通信
+- **状态管理：** UI (`main.ts`) 将值直接应用到 `PVEngine` 属性。不要使用全局状态管理器。
+- **更新循环：** 传递给效果的值在每次调用 `update(ctx)` 时被打包在 `UpdateContext` 参数中。尽可能依赖上下文属性如 `ctx.time`、`ctx.beatIntensity` 和 `ctx.palette`，而不是在内部跟踪状态。
+- **颜色解析：** 当设计可以接受彩色输入的效果时，使用 `resolveColor(colorString, ctx.palette)` 助手（来自 `src/core/types.ts`）。这允许支持动态主题占位符，如 `'$primary'` 或 `'$accent'`。
+
+### 4. 代码标准与文件头
+- 确保使用 `Record<string, any>` (如有必要) 对所有新配置属性进行适当的类型定义，但尽可能偏好严格的类型。
+- **许可文件头：** 每个 TypeScript 文件**必须**以以下内容开头：
+  ```typescript
+  // PV Tool — Copyright (c) 2026 DanteAlighieri13210914
+  // Licensed under AGPL-3.0. For commercial use, see COMMERCIAL.md
+  ```

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -72,6 +72,7 @@ export class PVEngine {
   private _resizeParent: HTMLElement | null = null;
   private _loading = false;
   private _bgColorOverride: string | null = null;
+  private _fontFamilyOverride: string | null = null;
   private _tick = 0;
   private _playbackTime = 0;
   private _paused = false;
@@ -220,6 +221,15 @@ export class PVEngine {
         const config = { ...entry.config };
         if (this.userText) {
           config._userText = this.textSegments[0] || this.userText;
+        }
+
+        if (this._fontFamilyOverride) {
+          if (config.fontFamily) {
+            config.fontFamily = `${this._fontFamilyOverride}, ${config.fontFamily}`;
+          } else {
+            // Provide a sensible fallback if the template effect didn't have one
+            config.fontFamily = `${this._fontFamilyOverride}, "Noto Serif JP", "Yu Mincho", serif`;
+          }
         }
 
         try {
@@ -558,6 +568,14 @@ export class PVEngine {
     }
   }
   get canvasColor() { return this._bgColorOverride; }
+
+  set fontFamily(font: string | null) {
+    this._fontFamilyOverride = font;
+    if (this.currentTemplate) {
+      this.loadTemplate(this.currentTemplate);
+    }
+  }
+  get fontFamily() { return this._fontFamilyOverride; }
 
   set hueShift(degrees: number) {
     this._hueShift = degrees;

--- a/src/effects/centeredSquares.ts
+++ b/src/effects/centeredSquares.ts
@@ -88,12 +88,13 @@ export class CenteredSquares extends BaseEffect {
     const spacing = chars.length > 1 ? totalSpread / (chars.length - 1) : 0;
     const startX = cx - totalSpread / 2;
     const fontSize = this.config.fontSize ?? 52;
+    const fontFamily = this.config.fontFamily ?? '"Noto Serif JP", serif';
 
     for (let i = 0; i < chars.length; i++) {
       const ct = new PIXI.Text({
         text: chars[i],
         style: {
-          fontFamily: '"Noto Serif JP", serif',
+          fontFamily,
           fontSize,
           fontWeight: '900' as PIXI.TextStyleFontWeight,
           fill: '#ffffff',

--- a/src/effects/layeredText.ts
+++ b/src/effects/layeredText.ts
@@ -90,7 +90,7 @@ export class LayeredText extends BaseEffect {
     const textObj = new PIXI.Text({
       text,
       style: {
-        fontFamily: '"Noto Serif JP", serif',
+        fontFamily: this.config.fontFamily ?? '"Noto Serif JP", serif',
         fontSize,
         fontWeight: '900' as PIXI.TextStyleFontWeight,
         fill: color,

--- a/src/effects/textStrip.ts
+++ b/src/effects/textStrip.ts
@@ -51,7 +51,7 @@ export class TextStrip extends BaseEffect {
 
     for (let i = 0; i < chars.length; i++) {
       const style = new PIXI.TextStyle({
-        fontFamily: '"Noto Serif JP", "Yu Mincho", serif',
+        fontFamily: this.config.fontFamily ?? '"Noto Serif JP", "Yu Mincho", serif',
         fontSize,
         fontWeight: 'bold',
         fill: textColor,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -12,6 +12,8 @@ export const en: Record<LocaleKey, string> = {
   'template': 'Template',
   'custom': '✦ Custom',
   'canvas_color': 'Canvas Color',
+  'font_label': 'Font',
+  'load_local_fonts': 'Load Local Fonts',
   'follow_template': 'Follow Template',
   'text_label': 'Text (split with /)',
   'expand': 'Expand',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -12,6 +12,8 @@ export const ja: Record<LocaleKey, string> = {
   'template': 'テンプレート Template',
   'custom': '✦ カスタム Custom',
   'canvas_color': 'キャンバス色 Canvas',
+  'font_label': 'フォント Font',
+  'load_local_fonts': 'ローカルフォントを取得',
   'follow_template': 'テンプレに従う',
   'text_label': 'テキスト Text（/で分割）',
   'expand': '展開',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -10,6 +10,8 @@ export const zh = {
   'template': '模板 Template',
   'custom': '✦ Custom 自定义',
   'canvas_color': '画布色 Canvas',
+  'font_label': '字体 Font',
+  'load_local_fonts': '获取本机字体',
   'follow_template': '跟随模板',
   'text_label': '文字 Text（用 / 分段）',
   'expand': '展开',

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,6 +86,20 @@ app.innerHTML = `
       </div>
 
       <div class="control-group">
+        <label>${t('font_label')}</label>
+        <div style="display: flex; gap: 8px;">
+          <select id="font-select" style="flex: 1;">
+            <option value="">${t('follow_template')}</option>
+          </select>
+          <button class="btn btn-sm" id="btn-load-fonts" title="${t('load_local_fonts')}" style="padding: 0 8px;">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 3v18h18"/><path d="M7 16V9a2 2 0 0 1 2-2h1.4c1.1 0 2 .9 2 2v7"/><path d="M7 12h5.4"/><path d="M15 16v-3a2 2 0 0 1 2-2h1.4c1.1 0 2 .9 2 2v3"/><path d="M15 12h5.4"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="control-group">
         <label>${t('text_label')}</label>
         <textarea id="text-input" rows="1" placeholder="深夜東京/の6畳半夢">深夜東京/の6畳半夢/を見てた/灯りの灯らない蛍光灯/明日には消えてる電脳城/に/開幕戦/打ち上げて/いなくなんないよね/ここには誰もいない/ここには誰もいないから</textarea>
       </div>
@@ -415,6 +429,68 @@ swatchContainer.addEventListener('click', (e) => {
   const color = btn.dataset.color;
   engine.canvasColor = color || null;
 });
+
+// Font select
+const fontSelect = document.getElementById('font-select') as HTMLSelectElement;
+fontSelect.addEventListener('change', () => {
+  engine.fontFamily = fontSelect.value || null;
+});
+
+const btnLoadFonts = document.getElementById('btn-load-fonts') as HTMLButtonElement;
+
+async function loadLocalFonts(isUserClick = false) {
+  if (!('queryLocalFonts' in window)) {
+    if (isUserClick) {
+      alert('Your browser does not support the Local Font Access API.');
+    }
+    return;
+  }
+  try {
+    // @ts-ignore
+    const fonts = await window.queryLocalFonts();
+    const uniqueFamilies = new Set<string>();
+    for (const font of fonts) {
+      if (font.family) {
+        uniqueFamilies.add(font.family);
+      }
+    }
+    const currentVal = fontSelect.value;
+    const sorted = Array.from(uniqueFamilies).sort();
+    
+    let html = `<option value="">${t('follow_template')}</option>`;
+    for (const family of sorted) {
+      // LocalFontAccess API returns font variants, but for the web we just need the family name.
+      // E.g. "Segoe UI". We inject it directly into a standard CSS string.
+      const safeFamily = family.replace(/"/g, '&quot;');
+      const cssValue = `"${safeFamily}"`;
+      html += `<option value='${cssValue}'>${family}</option>`;
+    }
+    fontSelect.innerHTML = html;
+    
+    if (currentVal) {
+      fontSelect.value = currentVal;
+    }
+    if (fontSelect.value !== currentVal) {
+      fontSelect.value = '';
+      engine.fontFamily = null;
+    }
+    btnLoadFonts.style.opacity = '0.5';
+    btnLoadFonts.disabled = true;
+    btnLoadFonts.title = 'Fonts loaded';
+  } catch (err) {
+    console.error('Failed to load fonts:', err);
+    if (isUserClick) {
+      alert('Failed to load local fonts. Please ensure you granted permission.');
+    }
+  }
+}
+
+btnLoadFonts.addEventListener('click', () => {
+  loadLocalFonts(true);
+});
+
+// Try to auto-load on startup
+loadLocalFonts(false);
 
 // Template
 const templateSelect = document.getElementById('template-select') as HTMLSelectElement;


### PR DESCRIPTION
feat: 添加自定义字体选择功能，支持加载本地字体并更新效果；修复部分效果不适配自定义字体的问题；增加了适用于Vibe Coding的Copilot提示文件

通过浏览器原生的 Local Font Access API 自动获取本机安装的所有系统字体。
使用现代浏览器的 window.queryLocalFonts() 接口异步获取本机的所有可用字体。
由于处于隐私安全考虑，现代浏览器直接在加载时静默请求字体会被拦截弹窗。因此做了一个折中的优雅处理：
若此前已提供过本站获取字体的权限，系统会在打开网页时自动加载出本机的全部字体到下拉框中；
如果是首次访问不支持自动授权，下拉选择框侧增设了一个获取字体的小按钮（包含特殊的文字图标）。点击该按钮即可浏览器授权，获得所有系统中渲染的本地字体。

<img width="660" height="569" alt="image" src="https://github.com/user-attachments/assets/bea12c0b-6561-463e-b592-ee3ffcf591f5" />


> [!IMPORTANT]
> Local Fonts Access API 目前是一项高级实验性规范，只有 Chrome, Edge 等新版 Chromium 内核的电脑端浏览器 才完全支持它。
> 如果您点击按钮依然未弹出授予“本地字体”权限对话框（提示不支持该 API），证明您的浏览器不支持此功能，此时默认字体表现将依靠备用的 CSS 网络字体 (Noto Sans JP / Noto Serif JP)