### PR TITLE
feat: 新增模板按钮网格，解决 OBS 浏览器源无法切换模板的问题

### DIFF
--- a/src/core/templateButtons.ts
+++ b/src/core/templateButtons.ts
@@ -1,0 +1,90 @@
+// PV Tool — Copyright (c) 2026 DanteAlighieri13210914
+// Licensed under Non-Commercial License. See LICENSE for terms.
+
+/**
+ * templateButtons.ts
+ *
+ * Renders template choices as clickable <button> elements instead of a
+ * <select> dropdown.  This is necessary for OBS browser-source users:
+ * OBS's embedded Chromium does not forward pointer events to <select>
+ * elements, so the dropdown is effectively unusable in the interaction
+ * window.  Plain <button> elements work perfectly.
+ *
+ * Usage
+ * -----
+ * Call `initTemplateButtons(templateSelect, () => customTemplates)` once
+ * after the DOM is ready.  The function inserts a button grid immediately
+ * before the hidden <select> and keeps the two in sync automatically.
+ *
+ * When the custom-template list changes (add / delete / import) call
+ * `rebuildTemplateButtons()` to regenerate the grid.
+ */
+
+import { templates } from '../templates';
+import type { TemplateConfig } from './types';
+import { t } from '../i18n';
+
+function tplName(tpl: TemplateConfig): string {
+  return tpl.nameKey ? t(tpl.nameKey as any) : tpl.name;
+}
+
+/**
+ * Initialise the button grid.
+ *
+ * @param templateSelect      The hidden <select id="template-select"> element.
+ * @param getCustomTemplates  Getter that returns the current custom-template array.
+ */
+export function initTemplateButtons(
+  templateSelect: HTMLSelectElement,
+  getCustomTemplates: () => TemplateConfig[],
+): void {
+  // Create the container and insert it before the <select>
+  const container = document.createElement('div');
+  container.id = 'template-buttons';
+  templateSelect.parentElement!.insertBefore(container, templateSelect);
+
+  function rebuild(): void {
+    const custom = getCustomTemplates();
+    container.innerHTML = [
+      ...templates.map((tp, i) =>
+        `<button class="tpl-btn" data-idx="${i}">${tplName(tp)}</button>`),
+      ...custom.map((tp, i) =>
+        `<button class="tpl-btn" data-idx="user-${i}">⭐ ${tp.name}</button>`),
+      `<button class="tpl-btn" data-idx="custom">${t('custom')}</button>`,
+    ].join('');
+    syncActive();
+  }
+
+  function syncActive(): void {
+    container.querySelectorAll<HTMLButtonElement>('.tpl-btn').forEach(btn => {
+      btn.classList.toggle('tpl-btn-active', btn.dataset.idx === templateSelect.value);
+    });
+  }
+
+  // Button click → drive the hidden <select> → fire its 'change' event
+  container.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.tpl-btn');
+    if (!btn) return;
+    templateSelect.value = btn.dataset.idx!;
+    templateSelect.dispatchEvent(new Event('change'));
+  });
+
+  // Keep highlight in sync whenever the select changes by any means
+  templateSelect.addEventListener('change', syncActive);
+
+  rebuild();
+
+  // Expose rebuild so callers can refresh after custom-template mutations
+  (container as any).__rebuild = rebuild;
+}
+
+/**
+ * Rebuild the button grid (call after adding / deleting / importing a
+ * custom template so the new entry appears immediately).
+ */
+export function rebuildTemplateButtons(): void {
+  const container = document.getElementById('template-buttons');
+  if (container && typeof (container as any).__rebuild === 'function') {
+    (container as any).__rebuild();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
 import { testNowPlayingConnection } from './core/nowPlayingProvider';
 import { initCopyUrlButton } from './core/copyUrl';
 import { showToast, attachModalDismiss } from './core/uiHelpers';
+import { initTemplateButtons, rebuildTemplateButtons } from './core/templateButtons';
 
 console.log('%cPV Tool%c solaris:0914', 'color:#6688cc;font-weight:bold', 'color:#888');
 
@@ -354,6 +355,7 @@ engine.init(container).then(() => {
   syncOpacitySlider();
   syncPostfxSliders();
   updateTemplateButtons();
+  initTemplateButtons(templateSelect, () => customTemplates);
 
   // URL param: bg (transparent background)
   const bgParam = urlParams.get('bg');
@@ -538,6 +540,7 @@ function rebuildTemplateSelect() {
     `<option value="user-${i}">⭐ ${tp.name}</option>`
   ).join('');
   templateSelect.innerHTML = builtInHtml + customHtml + `<option value="custom">${t('custom')}</option>`;
+  rebuildTemplateButtons();
 }
 
 function updateTemplateButtons() {
@@ -548,6 +551,7 @@ function updateTemplateButtons() {
   // Hide inline inputs when switching
   tplSaveInput.style.display = 'none';
   tplDeleteConfirm.style.display = 'none';
+  rebuildTemplateButtons();
 }
 
 const tplSaveBtn = document.getElementById('tpl-save')!;

--- a/src/style.css
+++ b/src/style.css
@@ -738,3 +738,9 @@ body.pv-panels-hidden .mobile-toggle {
   z-index: 10000;
   white-space: normal;
 }
+
+/* Template button grid (OBS-compatible selector) */
+#template-buttons { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.tpl-btn { padding: 4px 8px; font-size: 11px; cursor: pointer; background: #2a2a2a; color: #ccc; border: 1px solid #444; border-radius: 3px; white-space: nowrap; }
+.tpl-btn:hover { background: #3a3a3a; color: #fff; }
+.tpl-btn-active { background: #5566cc !important; border-color: #8899ff !important; color: #fff !important; }


### PR DESCRIPTION
 背景

OBS 浏览器源的内置 Chromium 存在已知限制：无法响应 `<select>` 下拉菜单的点击事件，导致用户在 OBS 交互窗口中完全无法切换模板，严重影响直播场景下的使用体验。

 解决方案

将模板选择器在视觉上替换为一排可点击的 `<button>` 小按钮。原有的 `<select>` 元素保留但隐藏，按钮点击后会驱动 select 触发 change 事件，与现有的所有模板切换逻辑（自定义模板、BroadcastChannel 同步等）完全兼容。

改动内容

- 新增 `src/core/templateButtons.ts`：按钮网格的完整实现，逻辑与 main.ts 解耦
- `src/main.ts`：新增 import 及三处调用（初始化、模板增删时重建、切换时高亮同步）
- `src/style.css`：新增按钮样式，含悬停效果和激活状态高亮

效果

- OBS 浏览器源交互窗口（`?bg=0`）中可直接点击按钮切换模板
- 普通浏览器中同样正常工作，与原有下拉菜单行为完全一致
- 自定义模板（⭐标记）增删后按钮网格自动刷新
- 当前激活模板按钮高亮显示