### PR TITLE
fix: 样式优化

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -523,7 +523,6 @@ input[type='range'] {
     flex-direction: column;
     gap: 10px;
     position: fixed;
-    bottom: 0;
     left: 0;
     right: 0;
     bottom: 10px;

--- a/src/style.css
+++ b/src/style.css
@@ -41,10 +41,12 @@ body {
   gap: 16px;
   backdrop-filter: blur(10px);
   min-width: 220px;
+  max-width: calc(100% - 268px);
   max-height: calc(100vh - 32px);
   overflow-y: auto;
   border: 1px solid rgba(255, 255, 255, 0.1);
   font-size: 0.85rem;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
 }
 
 .collapsible-section {
@@ -519,16 +521,23 @@ input[type='range'] {
   .panels-wrapper {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 10px;
     position: fixed;
     bottom: 0;
     left: 0;
     right: 0;
+    bottom: 10px;
     z-index: 100;
     max-height: 55vh;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     transition: transform 0.25s ease;
+    scrollbar-width: none;
+  }
+
+  .panels-wrapper::-webkit-scrollbar {
+    width: 0 !important;
+    display: none;
   }
 
   .panels-wrapper.panels-hidden {
@@ -540,20 +549,16 @@ input[type='range'] {
   .controls-right {
     position: relative;
     top: auto;
-    left: auto;
+    left: 10px;
     right: auto;
     bottom: auto;
-    border-radius: 0;
     min-width: unset;
     width: 100%;
     max-height: none;
     overflow-y: visible;
     padding: 14px 16px;
     gap: 10px;
-  }
-
-  .panels-wrapper > .controls:first-child {
-    border-radius: 12px 12px 0 0;
+    max-width: calc(100% - 20px);
   }
 
   .controls-bottom {

--- a/src/style.css
+++ b/src/style.css
@@ -563,14 +563,10 @@ input[type='range'] {
 
   .controls-bottom {
     position: relative;
-    top: auto;
-    left: auto;
     bottom: auto;
     transform: none;
     min-width: unset;
-    max-width: unset;
     width: 100%;
-    border-radius: 0;
     max-height: none;
     overflow-y: visible;
   }


### PR DESCRIPTION
1. 调整滚动条样式使其不再突兀。
2. 调整`.controls`样式，确保其在PC和移动端下都正常显示，不出现重叠。

## 改动前

<img height="500" alt="改动前1" src="https://github.com/user-attachments/assets/ec5b2a6d-677c-44a8-af86-6e496d86ef02" />

<img height="500" alt="改动前2" src="https://github.com/user-attachments/assets/fd12a790-75fc-4b73-b36f-7c3e292ba9fe" />

## 改动后

<img height="500" alt="改动后1" src="https://github.com/user-attachments/assets/b21909e4-b822-4419-bd7e-49db43316281" />  

<img height="500" alt="改动后2" src="https://github.com/user-attachments/assets/8830ba3a-9619-423d-975c-9066c80e5f0a" />  

<img height="500" alt="改动后3" src="https://github.com/user-attachments/assets/413c5dc7-7daa-4a2e-a1dc-34c8a1c65628" />  

<img height="500" alt="改动后4" src="https://github.com/user-attachments/assets/e82b153d-15f5-4e17-9afe-e4428c10c981" />  

